### PR TITLE
Fix build error in flare/src/admix/AdmixMain.java

### DIFF
--- a/src/admix/IbsHaps.java
+++ b/src/admix/IbsHaps.java
@@ -24,7 +24,7 @@ import java.util.Arrays;
 import java.util.stream.IntStream;
 import vcf.Steps;
 
-/**
+/*
  * <p>Class {@code IbsHaps} partitions a chromosome into genomic intervals
  * and for each genomic interval and target haplotype stores a reference
  * haplotype that is identical by state with the target haplotype in a long
@@ -33,7 +33,7 @@ import vcf.Steps;
  *
  * <p>Instances of class {@code IbsHaps} are immutable.</p>
  *
- * <p>Reference: Durbin, R. 2014. Bioinformatics 30(9):1266–1272.
+ * <p>Reference: Durbin, R. 2014. Bioinformatics 30(9):1266-1272.
  * doi:10.1093/bioinformatics/btu014</p>
  *
  * @author Brian L. Browning {@code <browning@uw.edu>}


### PR DESCRIPTION
The following error is encountered when bulding with recent Java LTS (US) builds:

% javac -cp flare/src/ flare/src/admix/AdmixMain.java
	flare/src/admix/IbsHaps.java:36: error:
		unmappable character (0xE2) for encoding US-ASCII
	* <p>Reference: Durbin, R. 2014. Bioinformatics 30(9):1266???1272. ^ flare/src/admix/IbsHaps.java:36: error: unmappable character (0x80) for encoding US-ASCII
	* <p>Reference: Durbin, R. 2014. Bioinformatics 30(9):1266???1272. ^ flare/src/admix/IbsHaps.java:36: error: unmappable character (0x93) for encoding US-ASCII
	* <p>Reference: Durbin, R. 2014. Bioinformatics 30(9):1266???1272. ^ 3 errors

It appears that the parser may not recognize the flagged character as part of the standard comment.