### PR TITLE
Add support for bref3 reference files

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,19 +75,27 @@ fill in the missing genotypes using the
 [Beagle](https://faculty.washington.edu/browning/beagle/beagle.html) program.
 Any input file with a name ending in ".gz" is assumed to be gzip-compressed.
 
-* **ref=[file]** where **[file]** is the reference VCF file that contains
-genotype data for each reference sample. Flare will ignore samples in the
-reference VCF file that are not present in the reference panel file
-(see the **ref-panel** parameter).
+* **ref=[file]** where **[file]** is the reference file that contains
+genotype data for each reference sample. This file may be in either VCF 
+or bref3 format. You can convert a reference VCF file to the bref3 format
+using the bref3 program obtainable through the 
+[Beagle homepage](https://faculty.washington.edu/browning/beagle/beagle.html). 
+Using the bref3 format should make Flare run faster. If a VCF file is provided, 
+Flare will ignore samples in reference VCF file that are not present in the 
+reference panel file. If a bref3 file is provided, the reference file must
+contain the same samples as are in the reference panel file. See the 
+**ref-panel** section for more information about parameter.
 
 * **ref-panel=[file]** where **[file]** is a reference panel file with two
 white-space-delimited fields per line. The first field is a sample identifier
 in the reference VCF file (see the **ref** parameter), and the second field
 is the name of the reference panel containing the reference sample.
-Flare will ignore samples in the reference VCF file that are not present
-in the reference panel file. A reference panel should contain individuals
-from the same source population. A reference panel should not normally
-contain admixed samples.
+If a VCF file used as the reference file, Flare will ignore samples in reference
+VCF file that are not present in the reference panel file. If a bref3 file used
+as the reference file, the reference file must contain the same samples as are 
+in the reference panel file. A reference panel should contain individuals from 
+the same source population. A reference panel should not normally contain
+admixed samples.
 
 * **gt=[file]** where **[file]** is the study VCF file containing genotype
 data for admixed study samples whose ancestry is to be inferred.

--- a/src/admix/AdmixPar.java
+++ b/src/admix/AdmixPar.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2021 Brian L. Browning
+ * Copyright 2023 Genomics plc
  *
  * This file is part of the flare program.
  *
@@ -205,7 +206,7 @@ public final class AdmixPar {
         return "Syntax: " + AdmixMain.COMMAND + " [arguments in format: parameter=value]" + nl
                 + nl
                 + "Required Parameters:" + nl
-                + "  ref=<VCF file with phased reference genotypes>       (required)" + nl
+                + "  ref=<VCF/BREF3 file with phased reference genotypes> (required)" + nl
                 + "  ref-panel=<file with reference sample to panel map>  (required)" + nl
                 + "  gt=<VCF file with phased genotypes to be analyzed>   (required)" + nl
                 + "  map=<PLINK map file with cM units>                   (required)" + nl
@@ -214,8 +215,8 @@ public final class AdmixPar {
                 + "Optional Parameters:" + nl
 //                + "  anc-panel=<file with ancestry to panels map>         (optional)" + nl
                 + "  array=<genotypes are from a SNP array: true/false>   (default: " + DEF_ARRAY + ")" + nl
-                + "  min-maf=<minimum MAF in reference VCF file>          (default: " + DEF_MIN_MAF + ")" + nl
-                + "  min-mac=<minimum MAC in reference VCF file>          (default: " + DEF_MIN_MAC + ")" + nl
+                + "  min-maf=<minimum MAF in reference file>              (default: " + DEF_MIN_MAF + ")" + nl
+                + "  min-mac=<minimum MAC in reference file>              (default: " + DEF_MIN_MAC + ")" + nl
                 + "  probs=<report ancestry probs: true/false>            (default: " + DEF_PROBS + nl
                 + "  gen=<number of generations since admixture>          (default: " + DEF_GEN + ")" + nl
                 + "  model=<file with model parameters>                   (optional)" + nl

--- a/src/bref/AsIsBref3Writer.java
+++ b/src/bref/AsIsBref3Writer.java
@@ -1,0 +1,422 @@
+/*
+ * Copyright 2021 Brian L. Browning
+ *
+ * This file is part of the flare program.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package bref;
+
+import beagleutil.ChromIds;
+import blbutil.FileUtil;
+import blbutil.Utilities;
+import ints.IntArray;
+import ints.IntList;
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import vcf.Marker;
+import vcf.RefGTRec;
+import vcf.Samples;
+
+/**
+ * <p>Class {@code AsIsBref3Writer} writes VCF data with phased, non-missing
+ * genotypes to a binary reference format v3 (bref) file.  Each record that
+ * is written will have the same internal representation (allele-coded or
+ * sequence-coded) as the {@code RefGTRec} passed to the {@code write()} method.
+ * The {@code close()} method must be called after the last invocation of the
+ * {@code write()} method in order to ensure that any buffered data are
+ * written to the output binary reference file.
+ * </p>
+ * <p>Instances of class {@code AsIsBref3Writer} are not thread-safe.</p>
+ *
+ * @author Brian L. Browning {@code <browning@uw.edu>}
+ */
+public class AsIsBref3Writer implements BrefWriter {
+
+    /**
+     * The end of file code for a bref file.
+     */
+    public static final int END_OF_DATA = 0;
+
+    /**
+     * The integer denoting denoting the end of the index in a bref file
+     */
+    public static final long END_OF_INDEX = -999_999_999_999_999L;
+
+    /**
+     * The initial integer in a bref version 3 file.
+     */
+    public static final int MAGIC_NUMBER_V3 = 2055763188;
+
+    /**
+     * The byte value denoting a sequence coded record
+     */
+    public static final byte SEQ_CODED = 0;
+
+    /**
+     * The byte value denoting an allele coded record
+     */
+    public static final byte ALLELE_CODED = 1;
+
+    private final String WRITE_ERR = "Error writing file";
+    private final String CONTIGUITY_ERR = "Error: chromosomes not contiguous";
+
+    private final Set<String> BASES_SET = basesSet();
+    private final String[][] SNV_PERMS = Bref3Reader.snvPerms();
+    private final Comparator<String[]> ALLELES_COMP = allelesComparator();
+
+    public final int MAX_SAMPLES = (1 << 29) - 1;
+
+    private int lastChromIndex = -1;
+    private IntArray hap2Seq = null;
+    private long bytesWritten = 0;
+
+    private final File bref;
+    private final Samples samples;
+    private final int nHaps;
+    private final List<RefGTRec> emBuffer;
+    private final List<BrefBlock> index;
+
+    private final DataOutputStream brefOut;
+    private final ByteArrayOutputStream baos;
+    private final DataOutputStream buffer;
+
+    /**
+     * Constructs a new {@code AsIsBref4Writer} for the specified data.
+     * The Java virtual machine will exit with an error message if an I/O
+     * error occurs during object construction
+     *
+     * @param program the name of the program which is creating the
+     * binary reference file.
+     * @param samples the list of samples whose genotype data will
+     * be written in binary reference format
+     * @param brefFile name of the output binary reference file or
+     * {@code null} if the output should be directed to standard output
+     *
+     * @throws IllegalArgumentException if {
+     * {@code samples.size() > AsIsBref4Writer.MAX_SAMPLES}
+     * @throws NullPointerException if {@code program == null || samples == null}
+     */
+    public AsIsBref3Writer(String program, Samples samples, File brefFile) {
+        if (program==null) {
+            throw new NullPointerException(String.class.toString());
+        }
+        if (samples.size() > MAX_SAMPLES) {
+            throw new IllegalArgumentException(String.valueOf(samples.size()));
+        }
+        this.bref = brefFile;
+        this.samples = samples;
+        this.nHaps = 2*samples.size();
+        this.emBuffer = new ArrayList<>(500);
+        this.index = new ArrayList<>(500);
+        this.brefOut = dataOutputStream(bref);
+        this.baos = new ByteArrayOutputStream(100);
+        this.buffer = new DataOutputStream(baos);
+        try {
+            brefOut.writeInt(MAGIC_NUMBER_V3);
+            bytesWritten += Integer.BYTES;
+            writeString(program, brefOut);
+            writeStringArray(samples.ids(), brefOut);
+        } catch (IOException ex) {
+            Utilities.exit(ex, WRITE_ERR);
+        }
+    }
+
+    @Override
+    public Samples samples() {
+        return samples;
+    }
+
+    @Override
+    public void write(RefGTRec rec) {
+        if (rec.samples().equals(samples)==false) {
+            Utilities.exit("ERROR: inconsistent data");
+        }
+        if (startNewBlock(rec)) {
+            writeAndClearBuffer();
+        }
+        emBuffer.add(rec);
+    }
+
+     private boolean startNewBlock(RefGTRec rec) {
+        boolean startNewBlock = false;
+        int cIndex = rec.marker().chromIndex();
+        if (cIndex!=lastChromIndex) {
+            lastChromIndex = cIndex;
+            hap2Seq = null;
+            startNewBlock = true;
+        }
+        if (rec.isAlleleCoded()==false) {
+            if (hap2Seq==null) {
+                hap2Seq = rec.map(0);
+            }
+            else if (rec.map(0)!=hap2Seq) {
+                hap2Seq = rec.map(0);
+                startNewBlock = true;
+            }
+        }
+        return startNewBlock;
+     }
+
+    @Override
+    public void close() {
+        try {
+            writeAndClearBuffer();
+            brefOut.writeInt(END_OF_DATA);
+            bytesWritten += Integer.BYTES;
+
+            long indexOffset = bytesWritten;
+            writeIndex();
+            brefOut.writeLong(indexOffset);
+            bytesWritten += Long.BYTES;
+
+            brefOut.close();
+
+        } catch (IOException ex) {
+            Utilities.exit(ex, "Error closing file");
+        }
+    }
+
+    private void writeAndClearBuffer() {
+        if (emBuffer.isEmpty()== false) {
+            try {
+                Marker m = emBuffer.get(0).marker();
+                index.add(new BrefBlock(m.chromIndex(), m.pos(), bytesWritten));
+                brefOut.writeInt(emBuffer.size());
+                bytesWritten += Integer.BYTES;
+                writeString(m.chrom(), brefOut);
+                writeHapToSeq();
+                for (int j=0, n=emBuffer.size(); j<n; ++j) {
+                    RefGTRec rec = emBuffer.get(j);
+                    if (rec.isAlleleCoded()) {
+                        writeAlleleCodedRec(rec);
+                    }
+                    else {
+                        writeSeqCodedRec(rec);
+                    }
+                }
+                emBuffer.clear();
+            } catch (IOException ex) {
+                Utilities.exit(ex, WRITE_ERR);
+            }
+        }
+    }
+
+    private void writeHapToSeq() throws IOException {
+        RefGTRec rec = null;
+        for (int j=0, n=emBuffer.size(); j<n && rec==null; ++j) {
+            RefGTRec candidate = emBuffer.get(j);
+            if (candidate.isAlleleCoded()==false) {
+                rec = candidate;
+            }
+        }
+        if (rec==null) {
+            brefOut.writeChar(0);
+            for (int j=0; j<nHaps; ++j) {
+                brefOut.writeChar(0);
+            }
+        }
+        else {
+            assert rec.nMaps()==2;
+            IntArray hapToSeq = rec.map(0);
+            IntArray seqToAllele = rec.map(1);
+            brefOut.writeChar(seqToAllele.size());
+            for (int j=0, n=hapToSeq.size(); j<n; ++j) {
+                brefOut.writeChar(hapToSeq.get(j));
+            }
+        }
+        bytesWritten += (nHaps + 1)*Character.BYTES;
+    }
+
+    private void writeSeqCodedRec(RefGTRec rec) throws IOException {
+        if (rec.marker().nAlleles() >= 256) {
+            Utilities.exit("ERROR: more than 256 alleles: " + rec.marker());
+        }
+        assert rec.nMaps()==2;
+        IntArray seq2Allele = rec.map(1);
+        writeMarker(rec.marker());
+        brefOut.writeByte(SEQ_CODED);
+        for (int j=0, n=seq2Allele.size(); j<n; ++j) {
+            brefOut.writeByte(seq2Allele.get(j));
+        }
+        bytesWritten += (seq2Allele.size() + 1) * Byte.BYTES;
+    }
+
+    private void writeAlleleCodedRec(RefGTRec rec) throws IOException {
+        assert rec.isAlleleCoded();
+        int nAlleles = rec.marker().nAlleles();
+        int majorAllele = rec.majorAllele();
+        writeMarker(rec.marker());
+        brefOut.writeByte(ALLELE_CODED);
+        bytesWritten += Byte.BYTES;
+        for (int a=0; a<nAlleles; ++a) {
+            if (a == majorAllele) {
+                brefOut.writeInt(-1);
+                bytesWritten += Integer.BYTES;
+            }
+            else {
+                int alCnt = rec.alleleCount(a);
+                brefOut.writeInt(rec.alleleCount(a));
+                for (int c=0; c<alCnt; ++c) {
+                    brefOut.writeInt(rec.hapIndex(a, c));
+                }
+                bytesWritten += (alCnt + 1)*Integer.BYTES;
+            }
+        }
+    }
+
+    private void writeMarker(Marker marker) throws IOException {
+        int nIds = Math.min(marker.nIds(), 255);
+        brefOut.writeInt(marker.pos());
+        brefOut.writeByte(nIds);
+        bytesWritten += (Integer.BYTES + Byte.BYTES);
+        for (int j=0; j<nIds; ++j) {
+            writeString(marker.id(j), brefOut);
+        }
+        byte alleleCode = isSNV(marker) ? snvCode(marker.alleles()) : -1;
+        brefOut.writeByte(alleleCode);
+        bytesWritten += Byte.BYTES;
+        if (alleleCode == -1) {
+            writeStringArray(marker.alleles(), brefOut);
+            brefOut.writeInt(marker.end());
+            bytesWritten += Integer.BYTES;
+        }
+    }
+
+    private byte snvCode(String[] alleles) {
+        int x = Arrays.binarySearch(SNV_PERMS, alleles, ALLELES_COMP);
+        if (x < 0) {
+            x = (-x - 1);
+        }
+        int code = (x << 2) + (alleles.length - 1);
+        return (byte) code;
+    }
+
+    private boolean isSNV(Marker marker) {
+        for (int j=0, n=marker.nAlleles(); j<n; ++j) {
+            if (BASES_SET.contains(marker.allele(j))==false) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static Comparator<String[]> allelesComparator() {
+        return (String[] o1, String[] o2) -> {
+            int n = Math.min(o1.length, o2.length);
+            for (int k=0; k<n; ++k) {
+                char c1 = o1[k].charAt(0);
+                char c2 = o2[k].charAt(0);
+                if (c1 != c2) {
+                    return (c1 < c2) ? -1 : 1;
+                }
+            }
+            if (o1.length != o2.length) {
+                return o1.length < o2.length ? -1 : 1;
+            }
+            else {
+                return 0;
+            }
+        };
+    }
+
+    private Set<String> basesSet() {
+        Set<String> set = new HashSet<>(4);
+        set.add("A");
+        set.add("C");
+        set.add("G");
+        set.add("T");
+        return Collections.unmodifiableSet(set);
+    }
+
+    private void writeIndex() throws IOException {
+        writeIndexChroms();
+        int lastChrIndex = -1;
+        for (int j=0, n=index.size(); j<n; ++j) {
+            BrefBlock bb = index.get(j);
+            long offset = bb.offset();
+            int ci = bb.chromIndex();
+            if (ci!=lastChrIndex) {
+                lastChrIndex = ci;
+                offset = -offset;
+            }
+            brefOut.writeLong(offset);
+            brefOut.writeInt(bb.pos());
+        }
+        brefOut.writeLong(END_OF_INDEX);
+        bytesWritten += (Long.BYTES + Integer.BYTES)*index.size() + Long.BYTES;
+    }
+
+    private void writeIndexChroms() throws IOException {
+        int lastChrIndex = -1;
+        List<String> chromList = new ArrayList<>();
+        IntList firstChromBlock = new IntList();
+        for (int j=0, n=index.size(); j<n; ++j) {
+            BrefBlock bb = index.get(j);
+            int ci = bb.chromIndex();
+            if (ci!=lastChrIndex) {
+                chromList.add(ChromIds.instance().id(ci));
+                firstChromBlock.add(j);
+                lastChrIndex = ci;
+            }
+        }
+        Set<String> set = new HashSet<>(chromList);
+        if (chromList.size() != set.size()) {
+            Utilities.exit(CONTIGUITY_ERR);
+        }
+        String[] chromIds = chromList.toArray(new String[0]);
+        int[] firstBlocks = firstChromBlock.toArray();
+        writeStringArray(chromIds, brefOut);
+        for (int b : firstBlocks) {
+            brefOut.writeInt(b);
+        }
+    }
+
+    private DataOutputStream dataOutputStream(File file) {
+        OutputStream dos;
+        if (file==null) {
+            dos = new DataOutputStream(System.out);
+        }
+        else {
+            dos = FileUtil.bufferedOutputStream(file);
+        }
+        return new DataOutputStream(dos);
+    }
+
+    private void writeStringArray(String[] sa, DataOutputStream dos)
+            throws IOException {
+        dos.writeInt(sa.length);
+        bytesWritten += Integer.BYTES;
+        for (String s : sa) {
+            writeString(s, dos);
+        }
+    }
+
+    private void writeString(String s, DataOutputStream dos)
+           throws IOException {
+        baos.reset();
+        buffer.writeUTF(s);
+        bytesWritten += baos.size();
+        baos.writeTo(dos);
+    }
+}

--- a/src/bref/Bref3It.java
+++ b/src/bref/Bref3It.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2021 Brian L. Browning
+ *
+ * This file is part of the flare program.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package bref;
+
+import blbutil.FileUtil;
+import blbutil.Filter;
+import blbutil.SampleFileIt;
+import blbutil.Utilities;
+import java.io.BufferedInputStream;
+import java.io.DataInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.NoSuchElementException;
+import vcf.Marker;
+import vcf.RefGTRec;
+import vcf.Samples;
+
+/**
+ * <p>Class {@code Bref3It} represents  an iterator whose {@code next()} which
+ * returns records from a bref version 3 file.
+ * </p>
+ * <p>Instances of class {@code Bref3It} are not thread-safe.
+ * </p>
+ * <p>Methods of this class will terminate the Java Virtual Machine with
+ * an error message if an I/O error or file format error is detected.
+ * </p>
+ *
+ * @author Brian L. Browning {@code <browning@uw.edu>}
+ */
+public final class Bref3It implements SampleFileIt<RefGTRec> {
+
+    private final File brefFile;
+    private final DataInputStream bref;
+    private final Bref3Reader bref3Reader;
+    private final Deque<RefGTRec> buffer;
+
+    /**
+     * Constructs a new {@code Bref3It} instance.
+     * @param brefFile a bref version 3 file or {@code null} if the
+     * bref version 3 file is to be read from standard input
+     *
+     * @throws IllegalArgumentException if a format error is detected in a
+     * line of the specified bref file
+     */
+    public Bref3It(File brefFile) {
+        this(brefFile, Filter.acceptAllFilter());
+    }
+
+    /**
+     * Constructs a new {@code Bref4It} instance.
+     * @param brefFile a bref v4 file
+     * @param markerFilter a marker filter or {@code null}
+     *
+     * @throws IllegalArgumentException if a format error is detected in a
+     * line of the specified bref v3 file
+     * @throws NullPointerException if {@code file == null}
+     */
+    public Bref3It(File brefFile, Filter<Marker> markerFilter) {
+        if (markerFilter == null) {
+            markerFilter = Filter.acceptAllFilter();
+        }
+        InputStream is = null;
+        if (brefFile==null) {
+            is = new BufferedInputStream(System.in);
+        }
+        else {
+            is = FileUtil.bufferedInputStream(brefFile);
+        }
+        this.brefFile = brefFile;
+        this.bref = new DataInputStream(is);
+        this.bref3Reader = new Bref3Reader(bref, markerFilter);
+        this.buffer = new ArrayDeque<>(500);
+        bref3Reader.readBlock(bref, buffer);
+    }
+
+    /**
+     * Returns {@code true} if the iteration has more elements, and returns
+     * {@code false} otherwise.
+     * @return {@code true} if the iteration has more elements
+     */
+    @Override
+    public boolean hasNext() {
+        return !buffer.isEmpty();
+    }
+
+    /**
+     * Returns the next element in the iteration.
+     * @return the next element in the iteration
+     * @throws NoSuchElementException if the iteration has no more elements
+     */
+    @Override
+    public RefGTRec next() {
+        if (hasNext()==false) {
+            throw new NoSuchElementException();
+        }
+        RefGTRec rec = buffer.removeFirst();
+        if (buffer.isEmpty()) {
+            bref3Reader.readBlock(bref, buffer);
+        }
+        return rec;
+    }
+
+    @Override
+    public void close() {
+        try {
+            bref.close();
+        } catch (IOException ex) {
+            Utilities.exit(ex, "Error closing file");
+        }
+        buffer.clear();
+    }
+
+    @Override
+    public File file() {
+        return brefFile;
+    }
+
+    @Override
+    public Samples samples() {
+        return bref3Reader.samples();
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder(80);
+        sb.append(this.getClass().toString());
+        sb.append(" : ");
+        sb.append(brefFile);
+        return sb.toString();
+    }
+}

--- a/src/bref/Bref3Reader.java
+++ b/src/bref/Bref3Reader.java
@@ -1,0 +1,326 @@
+/*
+ * Copyright 2021 Brian L. Browning
+ *
+ * This file is part of the flare program.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package bref;
+
+import beagleutil.ChromIds;
+import blbutil.Const;
+import blbutil.Filter;
+import blbutil.Utilities;
+import ints.CharArray;
+import ints.IntArray;
+import ints.UnsignedByteArray;
+import java.io.DataInput;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import vcf.BasicMarker;
+import vcf.Marker;
+import vcf.RefGTRec;
+import vcf.Samples;
+import vcf.SeqCodedRefGTRec;
+
+/**
+ * <p>Class {@code Bref3Reader} contains methods for reading a bref 3
+ * (binary reference format) file.
+ * </p>
+ * <p>Instances of class {@code Bref3Reader} are not thread-safe.
+ * </p>
+ * <p>Methods of this class will terminate the Java Virtual Machine with
+ * an error message if an I/O error or file format error is detected.
+ * </p>
+ *
+ * @author Brian L. Browning {@code <browning@uw.edu>}
+ */
+public final class Bref3Reader {
+
+    static final String READ_ERR = "Error reading file";
+    private static final String[][] SNV_PERMS = snvPerms();
+
+    private final Filter<Marker> markerFilter;
+    private final String program;
+    private final Samples samples;
+    private final int nHaps;
+    private final byte[] byteBuffer;
+
+    /**
+     * Constructs a new {@code Bref3Reader} instance.
+     * @param bref a {@code DataInput} instance reading from a bref v3 file
+     * @param markerFilter a marker filter or {@code null}
+     *
+     * @throws IllegalArgumentException if a format error is detected in a
+     * line of the specified bref v3 file
+     * @throws NullPointerException if {@code file == null}
+     */
+    public Bref3Reader(DataInput bref, Filter<Marker> markerFilter) {
+        if (markerFilter == null) {
+            markerFilter = Filter.acceptAllFilter();
+        }
+        String[] sampleIds = null;
+        String programString = null;
+        try {
+            readAndCheckMagicNumber(bref);
+            programString = readString(bref);
+            sampleIds = readStringArray(bref);
+        } catch (IOException ex) {
+            Utilities.exit(ex, READ_ERR);
+        }
+        boolean[] isDiploid = new boolean[sampleIds.length];
+        Arrays.fill(isDiploid, true);
+        this.program = programString;
+        this.samples = Samples.fromIds(sampleIds, isDiploid);
+        this.markerFilter = markerFilter;
+        this.nHaps = 2*samples.size();
+        this.byteBuffer = new byte[2*nHaps];
+    }
+
+    /**
+     * Returns the list of samples in the brefFile used to construct this
+     * instance
+     * @return the list of samples
+     */
+    Samples samples() {
+        return samples;
+    }
+
+    /**
+     * Returns the bref file program string in the brefFile used to
+     * construct this instance
+     * @return the program string
+     */
+    String program() {
+        return program;
+    }
+
+    /**
+     * Returns the marker filter
+     * @return the marker filter
+     */
+    Filter<Marker> markerFilter() {
+        return markerFilter;
+    }
+
+    /**
+     * Reads the next binary reference format data block.  The contract for
+     * this method is undefined if the next byte read from the specified
+     * {@code DataInput} object is not the first byte of a bref data block
+     * or is not the first byte of the sentinal denoting no more
+     * bref data blocks.
+     * @param bref the bref file and associated file pointer
+     * @param buffer the collection to which the next block of records
+     * will be added
+     * @throws NullPointerException if {@code bref == null || buffer == null}
+     */
+    void readBlock(DataInput bref, Collection<RefGTRec> buffer) {
+        try {
+            int nRecs = Integer.MAX_VALUE;
+            while (buffer.isEmpty() && nRecs!=0) {
+                nRecs = bref.readInt();
+                if (nRecs!=0) {
+                    readBlock(bref, buffer, nRecs);
+                }
+            }
+        } catch (IOException ex) {
+            Utilities.exit(ex, READ_ERR);
+        }
+    }
+
+    private void readBlock(DataInput bref, Collection<RefGTRec> buffer,
+            int nRecs) throws IOException {
+        assert nRecs!= 0;
+        String chrom = readString(bref);
+        int chromIndex = ChromIds.instance().getIndex(chrom);
+        int nSeq = bref.readUnsignedShort();
+        bref.readFully(byteBuffer);
+        IntArray hapToSeq = new CharArray(byteBuffer);
+        for (int j=0; j<nRecs; ++j) {
+            Marker marker = readMarker(bref, chromIndex);
+            byte flag = bref.readByte();
+            if (flag==0) {
+                RefGTRec rec = readSeqCodedRecord(bref, marker, samples,
+                        hapToSeq, nSeq);
+                if (markerFilter.accept(marker)) {
+                    buffer.add(rec);
+                }
+            }
+            else if (flag==1) {
+                RefGTRec rec = readHapCodedRec(bref, marker, samples);
+                if (markerFilter.accept(marker)) {
+                    buffer.add(rec);
+                }
+            }
+            else {
+                Utilities.exit(READ_ERR);
+            }
+        }
+    }
+
+    private RefGTRec readSeqCodedRecord(DataInput bref, Marker marker,
+            Samples samples, IntArray hapToSeq, int nSeq) throws IOException {
+        bref.readFully(byteBuffer, 0, nSeq);
+        IntArray seqToAllele = new UnsignedByteArray(byteBuffer, 0, nSeq);
+
+//        // following code can be uncommented to check data consistency
+//        if (seqToAllele.max() >= marker.nAlleles()) {
+//            throw new IllegalArgumentException("inconsistent data");
+//        }
+
+        return new SeqCodedRefGTRec(marker, samples, hapToSeq, seqToAllele);
+    }
+
+    private static void readAndCheckMagicNumber(DataInput di) throws IOException {
+        int magicNumber=di.readInt();
+        if (magicNumber!=AsIsBref3Writer.MAGIC_NUMBER_V3) {
+            String s = "ERROR: Unrecognized input file.  Was input file created "
+                    + Const.nl + "with a different version of the bref program?";
+            Utilities.exit(s);
+        }
+    }
+
+    private static Marker readMarker(DataInput di, int chromIndex)
+            throws IOException {
+        int pos = di.readInt();
+        String[] ids = readByteLengthStringArray(di);
+        byte alleleCode = di.readByte();
+        if (alleleCode == -1) {
+            String[] strAlleles = readStringArray(di);
+            int end = di.readInt();
+            return new BasicMarker(chromIndex, pos, ids, strAlleles, end);
+        }
+        else {
+            int nAlleles = 1 + (alleleCode & 0b11);
+            int permIndex = alleleCode >> 2;
+            String[] strAlleles = alleleString(permIndex, nAlleles);
+            int end = -1;
+            return new BasicMarker(chromIndex, pos, ids, strAlleles, end);
+        }
+    }
+
+    private static RefGTRec readHapCodedRec(DataInput di, Marker marker,
+            Samples samples) throws IOException {
+        int nAlleles = marker.nAlleles();
+        int[][] hapIndices = new int[nAlleles][];
+        for (int j=0; j<nAlleles; ++j) {
+            hapIndices[j] = readIntArray(di);
+        }
+        return RefGTRec.hapCodedInstance(marker, samples, hapIndices);
+    }
+
+    private static int[] readIntArray(DataInput di) throws IOException {
+        int length = di.readInt();
+        if (length == -1) {
+            return null;
+        }
+        else {
+            int[] ia = new int[length];
+            byte[] ba = new byte[4*length]; // will overflow if 4*length >= 2^31
+            di.readFully(ba);
+            for (int j=0; j<ba.length; j+=4) {
+                ia[j/4] = (((ba[j] & 0xff) << 24) | ((ba[j+1] & 0xff) << 16) |
+                            ((ba[j+2] & 0xff) << 8) | (ba[j+3] & 0xff));
+            }
+            return ia;
+        }
+    }
+
+    private static String readString(DataInput di) throws IOException {
+        return di.readUTF();
+    }
+
+    private static String[] readByteLengthStringArray(DataInput di)
+            throws IOException {
+        int length = di.readUnsignedByte();
+        return readStringArray(di, length);
+    }
+
+    static String[] readStringArray(DataInput di) throws IOException {
+        int length = di.readInt();
+        return readStringArray(di, length);
+    }
+
+    /* Returns null if length is negative */
+    private static String[] readStringArray(DataInput di, int length)
+            throws IOException {
+        if (length<0) {
+            return null;
+        } else if (length==0) {
+            return new String[0];
+        } else {
+            String[] sa=new String[length];
+            for (int j=0; j<sa.length; ++j) {
+                sa[j]=readString(di);
+            }
+            return sa;
+        }
+    }
+
+    static String[][] snvPerms() {
+        String[] bases=new String[]{"A", "C", "G", "T"};
+        List<String[]> perms=new ArrayList<>(24);
+        permute(new String[0], bases, perms);
+        return perms.toArray(new String[0][]);
+    }
+
+    private static void permute(String[] start, String[] end,
+            List<String[]> perms) {
+        if (end.length==0) {
+            perms.add(start);
+        }
+        else {
+            for (int j=0; j<end.length; ++j) {
+                String[] newStart = Arrays.copyOf(start, start.length + 1);
+                newStart[start.length] = end[j];
+
+                String[] newEnd = new String[end.length - 1];
+                if (j > 0) {
+                    System.arraycopy(end, 0, newEnd, 0, j);
+                }
+                if (j < newEnd.length) {
+                    System.arraycopy(end, j+1, newEnd, j, (newEnd.length - j));
+                }
+                permute(newStart, newEnd, perms);
+            }
+        }
+    }
+
+    /**
+     * Returns an array that is obtained by taking the first {@code length}
+     * elements of the specified permutation of "A", "C", "G", and "T".
+     * The list of 24 permutations of "A", "C", "G", and "T" are sorted
+     * in lexicographic order.
+     * @param permIndex an index of a permutation of the bases "A",
+     * "C", "G", and "T"
+     * @param length the number of elements in the returned array
+     * @return an array that is obtained by taking the first {@code length}
+     * elements of the specified permutation of "A", "C", "G", and "T"
+     * @throws IndexOutOfBoundsException if
+     * {@code permIndex < 0 || permIndex >= 24}
+     * @throws IndexOutOfBoundsException if {@code length < 0 || length >= 4}
+     */
+    private static String[] alleleString(int permIndex, int length) {
+        return Arrays.copyOf(SNV_PERMS[permIndex], length);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder(80);
+        sb.append(this.getClass().toString());
+        return sb.toString();
+    }
+}

--- a/src/bref/BrefBlock.java
+++ b/src/bref/BrefBlock.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2021 Brian L. Browning
+ *
+ * This file is part of the flare program.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package bref;
+
+import beagleutil.ChromIds;
+import blbutil.Const;
+
+/**
+ * <p>Class {@code BrefBlock} represents starting chromosome coordinates and
+ * file offset for the start of a binary reference format (bref) data block.
+ * </p>
+ *
+ * <p>Instances of class {@code BrefBlock} are immutable.
+ * </p>
+ *
+ * @author Brian L. Browning {@code <browning@uw.edu>}
+ */
+public class BrefBlock {
+
+    private final int chromIndex;
+    private final int pos;
+    private final long offset;
+
+    /**
+     * Constructs a {@code BrefBlock} for the specified data.  It is the
+     * caller's responsibility to ensure the consistency of the
+     * constructor parameters.
+     *
+     * @param chromIndex the chromosome index
+     * @param pos the starting chromosome position
+     * @param offset the file offset in bytes for the bref data block
+     */
+    public BrefBlock(int chromIndex, int pos, long offset) {
+        this.chromIndex = chromIndex;
+        this.pos = pos;
+        this.offset = offset;
+    }
+
+    /**
+     * Returns the chromosome index of the first marker in this bref block.
+     * @return the chromosome index of the first marker in this bref block
+     */
+    public int chromIndex() {
+        return chromIndex;
+    }
+
+    /**
+     * Returns the chromosome position of the first marker in this bref block.
+     * @return the chromosome position of the first marker in this bref block
+     */
+    public int pos() {
+        return pos;
+    }
+
+    /**
+     * Returns the file offset of the first marker in this bref block.
+     * @return the file offset of the first marker in this bref block
+     */
+    public long offset() {
+        return offset;
+    }
+
+    /**
+     * Returns a string description of {@code this}.  The exact details
+     * of the representation are unspecified and subject to change.
+     * @return  a string description of {@code this}
+     */
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder(30);
+        sb.append('[');
+        sb.append(ChromIds.instance().id(chromIndex));
+        sb.append(Const.tab);
+        sb.append(pos);
+        sb.append(Const.tab);
+        sb.append(offset);
+        sb.append(']');
+        return sb.toString();
+    }
+}

--- a/src/bref/BrefWriter.java
+++ b/src/bref/BrefWriter.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 Brian L. Browning
+ *
+ * This file is part of the flare program.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package bref;
+
+import java.io.Closeable;
+import vcf.RefGTRec;
+import vcf.Samples;
+
+/**
+ * <p>Interface {@code BrefWrites} writes phased, non-missing genotypes to a
+ * binary reference format (bref) file.  The {@code close()} method must
+ * be called after the last invocation of the {@code write()} method
+ * in order to ensure that any buffered data are written to the output
+ * binary reference file.
+ * </p>
+ * <p>Instances of class {@code BrefWriter} are not thread-safe.
+ * </p>
+ *
+ * @author Brian L. Browning {@code <browning@uw.edu>}
+ */
+public interface BrefWriter extends Closeable {
+
+    /**
+     * Returns the list of samples.
+     * @return the list of samples
+     */
+    Samples samples();
+
+    /**
+     * Writes the specified phased genotype data in binary reference format.
+     * The Java virtual machine will exit with an error message if an I/O
+     * error occurs during method execution, if {@code this.close()}
+     * has previously been invoked, or if
+     * {@code rec.samples().equals(this.samples()) == false}.
+     *
+     * @param rec phased genotype data
+     *
+     * @throws NullPointerException if {@code rec == null}
+     */
+    void write(RefGTRec rec);
+
+    /**
+     * Flushes any buffered output and releases any system resources that are
+     * held by this {@code BrefWriter}.  The Java virtual machine will exit
+     * with an error message if an I/O error occurs during method execution.
+     */
+    @Override
+    void close();
+}


### PR DESCRIPTION
This PR adds support for `.bref3` reference files in flare, as reading `bref3` reference files is quicker than reading `.vcf.gz` reference files. I've moved over bref3 reading source files from the beagle repository into the `bref` folder in this repository and changed the license to the Apache Licence (we've checked with Brian Browning and he was OK with this).

I've also enforced that `bref3` reference files must contain the same samples as the reference panel, due to the fact that existing `bref3` readers don't support sample filtering.

I have also added `Genomics plc` to the copyright header of `AdmixPar.java` and `AdmixReader.java`, the source files modified in this PR.

Here is a manual test of the added functionality:
```
$ java -jar flare.jar ref=ref.bref3 ref-panel=ref_panel.tsv gt=gt.vcf.gz map=plink.chr1.GRCh37.map model=input.model em=false probs=true array=true out=painted-using-bref3-reference nthreads=1 seed=12345
Copyright (C) 2022 Brian L. Browning
Enter "java -jar flare.jar" to print a list of command line arguments

Program             :  flare.jar  [ version 0.3.0, 20Oct22.2a6 ]
Start Time          :  04:59 PM UTC on 01 Nov 2023
Max Memory          :  16080 MB

Parameters
  ref               :  ref.bref3
  ref-panel         :  ref_panel.tsv
  gt                :  gt.vcf.gz
  map               :  plink.chr1.GRCh37.map
  out               :  painted-using-bref3-reference
  array             :  true
  min-maf           :  0.005
  probs             :  true
  model             :  input.model
  em                :  false
  nthreads          :  1
  seed              :  12345


Note: the minor allele count filter is not applied when 'array=true'

Statistics
  reference samples :  6307
  target samples    :  2
  markers           :  47996

Wallclock Time      :  45 seconds
End Time            :  04:59 PM UTC on 01 Nov 2023
$ java -jar flare.jar ref=ref.vcf.gz ref-panel=ref_panel.tsv gt=gt.vcf.gz map=plink.chr1.GRCh37.map model=input.model em=false probs=true array=true out=painted-using-vcf-reference nthreads=1 seed=12345
Copyright (C) 2022 Brian L. Browning
Enter "java -jar flare.jar" to print a list of command line arguments

Program             :  flare.jar  [ version 0.3.0, 20Oct22.2a6 ]
Start Time          :  05:00 PM UTC on 01 Nov 2023
Max Memory          :  16080 MB

Parameters
  ref               :  ref.vcf.gz
  ref-panel         :  ref_panel.tsv
  gt                :  gt.vcf.gz
  map               :  plink.chr1.GRCh37.map
  out               :  painted-using-vcf-reference
  array             :  true
  min-maf           :  0.005
  probs             :  true
  model             :  input.model
  em                :  false
  nthreads          :  1
  seed              :  12345


Note: the minor allele count filter is not applied when 'array=true'

Statistics
  reference samples :  6307
  target samples    :  2
  markers           :  47996

Wallclock Time      :  54 seconds
End Time            :  05:01 PM UTC on 01 Nov 2023

```
