### PR TITLE
Support sample specific ancestry priors

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,18 @@ in the **model** file with their estimated values.
 The model parameters used in the analysis are reported in the output
 [**.model**](#output-files) file.
 
+* **gt-ancestries=[file]** where **[file]** is a white-space delimited file. The
+first row is a header line containing `sample_id` followed by the names of all
+the ancestries defined in the model file, in the same order as in the model
+file. Following this line, each row starts with a sample identifier followed by
+a whitespace delimited list of proportions of target genotypes in each ancestry.
+All samples to be analysed must be included. Samples to be analysed are defined
+as those appear in **gt=[file]** and **gt-samples=[file]**, but not in
+**gt-samples=^[file]**. Additionally, **em** must be set to **false**, and a
+model file must be provided via **model=[file]**. When analysing the samples,
+**flare** will use parameters specific in the model file, but with the ancestry
+proportions replaced by the sample-specific values.
+
 * **em=[true/false]** specifies whether the number of generations since
 admixture and the proportion of genotypes with each ancestry will
 be estimated using an iterative expectation maximization (EM) algorithm

--- a/src/admix/AdmixRecBuilder.java
+++ b/src/admix/AdmixRecBuilder.java
@@ -1,5 +1,7 @@
 /*
  * Copyright 2021 Brian L. Browning
+ * 
+ * Copyright 2023 Genomics plc
  *
  * This file is part of the flare program.
  *
@@ -40,7 +42,6 @@ import vcf.RefGT;
  */
 public final class AdmixRecBuilder {
 
-    private final ParamsInterface params;
     private final RefGT targRefGT;
     private final int mStart;
     private final int mEnd;
@@ -68,7 +69,7 @@ public final class AdmixRecBuilder {
      * {@code (start < 0 || end > targRefGT.nMarkers() || end < start)}
      * @throws NullPointerException if {@code par == null || targRefGT == null}
      */
-    public AdmixRecBuilder(ParamsInterface params, RefGT targRefGT, int start,
+    public AdmixRecBuilder(FixedParams fixedParams, RefGT targRefGT, int start,
             int end) {
         if (start<0) {
             throw new IndexOutOfBoundsException(String.valueOf(start));
@@ -76,19 +77,17 @@ public final class AdmixRecBuilder {
         if (end<start || end>targRefGT.nMarkers()) {
             throw new IndexOutOfBoundsException(String.valueOf(end));
         }
-        FixedParams fp = params.fixedParams();
-        int nHaps = (fp.refSamples().size() + fp.targSamples().size())<<1;
+        int nHaps = (fixedParams.refSamples().size() + fixedParams.targSamples().size())<<1;
         if (targRefGT.nHaps() != nHaps) {
             throw new IllegalArgumentException(String.valueOf(targRefGT.nHaps()));
         }
         int mSize = end - start;
-        this.params = params;
         this.targRefGT = targRefGT;
         this.mStart = start;
         this.mEnd = end;
-        this.nTargHaps = (params.fixedParams().targSamples().size() << 1);
-        this.nAnc = params.fixedParams().nAnc();
-        this.printProbs = params.fixedParams().par().probs();
+        this.nTargHaps = (fixedParams.targSamples().size() << 1);
+        this.nAnc = fixedParams.nAnc();
+        this.printProbs = fixedParams.par().probs();
         this.probStart = nAnc*start;
         this.sampleData = new StringBuilder[mSize];
         int charPerHap = printProbs ? nAnc<<3 : nAnc<<1;
@@ -106,16 +105,6 @@ public final class AdmixRecBuilder {
      */
     public RefGT targRefGT() {
         return targRefGT;
-    }
-
-    /**
-     * Returns the analysis parameters for a local ancestry inference
-     * analysis
-     * @return the analysis parameters for a local ancestry inference
-     * analysis
-     */
-    public ParamsInterface params() {
-        return params;
     }
 
     /**

--- a/src/admix/AncEstimator.java
+++ b/src/admix/AncEstimator.java
@@ -1,6 +1,8 @@
 /*
  * Copyright 2021 Brian L. Browning
  *
+ * Copyright 2023 Genomics plc
+ * 
  * This file is part of the flare program.
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -22,6 +24,7 @@ import blbutil.Utilities;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 
 /**
  * <p>Class {@code AncEstimator} has static methods for estimating
@@ -37,33 +40,89 @@ public final class AncEstimator {
         // private constructor to prevent instantiation
     }
 
-   /**
+    /**
      * Runs a local ancestry inference analysis and write the output to the
      * specified {@code AdmixWriter}.
      * @param ibsHaps IBS segments
-     * @param params the local ancestry model parameters
+     * @param fixedParams the fixed parameters for a local ancestry inference
+     * analysis
+     * @param getSampleParams a {@code Function} that when given a sample index, returns 
+     * the parameters for that sample
      * @param globalAncProbs an object for storing global ancestry
      * probabilities
      * @param admixWriter an object to which output will be written
      * @throws IllegalArgumentException if
      * {@code params.par() != admixWriter.par()}
      * @throws NullPointerException if
-     * {@code (params == null) || (ibsHaps == null) || (globalAncProbs == null) || (admixWriter == null)}
+     * {@code (ibsHaps == null) || (params == null) || (globalAncProbs == null) ||  (admixWriter == null)}
      */
-    public static void estAncestry(ParamsInterface params, IbsHaps ibsHaps,
-            GlobalAncProbs globalAncProbs, AdmixWriter admixWriter) {
+    public static void estAncestry(IbsHaps ibsHaps, FixedParams fixedParams,
+            Function<Integer, ParamsInterface> getSampleParams, GlobalAncProbs globalAncProbs, AdmixWriter admixWriter) {
+        if (fixedParams.par() != admixWriter.par()) {
+            throw new IllegalArgumentException("inconsistent data");
+        }
+        EstimatedAncestry estAnc = estAncestry(fixedParams, getSampleParams, ibsHaps, globalAncProbs);
+        admixWriter.writeAncestry(estAnc);
+    }
+
+    private static EstimatedAncestry estAncestry(FixedParams fixedParams,
+            Function<Integer, ParamsInterface> getSampleParams, IbsHaps ibsHaps, GlobalAncProbs globalAncProbs) {
+        int nTargHaps = ibsHaps.chromData().nTargHaps();
+        EstimatedAncestry estAnc = new EstimatedAncestry(ibsHaps.chromData(), fixedParams, globalAncProbs);
+        AtomicInteger index = new AtomicInteger(0);
+        int nThreads = fixedParams.par().nthreads();
+        ExecutorService es = Executors.newFixedThreadPool(nThreads);
+
+        for (int j = 0; j < nThreads; ++j) {
+            es.submit(() -> {
+                try {
+                    int hapsI = index.getAndIncrement();
+                    ParamsInterface currentParams = null;
+                    AdmixHmm hmm = null;
+                    int lastSampleI = -1;
+
+                    while (hapsI < nTargHaps) {
+                        int sampleI = hapsI / 2;
+
+                        ParamsInterface newParams = getSampleParams.apply(sampleI);
+                        // Reuse the last hmm if `getSampleParams` always returns the same thing or we are on the same
+                        // sample.
+                        if (currentParams != newParams && lastSampleI != sampleI) {
+                            AdmixData data = new AdmixData(ibsHaps.chromData(), newParams);
+                            hmm = new AdmixHmm(data, ibsHaps);
+                            currentParams = newParams;
+
+                            // A lot of old objects have been disposed of, therefore GC now.
+                            System.gc();
+                        }
+                        
+                        hmm.runFwdBwdAnc(hapsI, estAnc);
+                        hapsI = index.getAndIncrement();
+                        lastSampleI = sampleI;
+
+                    }
+                } catch (Throwable t) {
+                    Utilities.exit(t);
+                }
+            });
+        }
+        MultiThreadUtils.shutdownExecService(es);
+        return estAnc;
+    }
+
+    public static void estAncestry(IbsHaps ibsHaps, ParamsInterface params, GlobalAncProbs globalAncProbs, AdmixWriter admixWriter) {
         if (params.fixedParams().par() != admixWriter.par()) {
             throw new IllegalArgumentException("inconsistent data");
         }
         EstimatedAncestry estAnc = estAncestry(params, ibsHaps, globalAncProbs);
         admixWriter.writeAncestry(estAnc);
     }
-
+    
     private static EstimatedAncestry estAncestry(ParamsInterface params,
             IbsHaps ibsHaps, GlobalAncProbs globalAncProbs) {
         AdmixData data = new AdmixData(ibsHaps.chromData(), params);
         int nTargHaps = ibsHaps.chromData().nTargHaps();
-        EstimatedAncestry estAnc = new EstimatedAncestry(data, globalAncProbs);
+        EstimatedAncestry estAnc = new EstimatedAncestry(ibsHaps.chromData(), params.fixedParams(), globalAncProbs);
         AtomicInteger index = new AtomicInteger(0);
         int nThreads = params.fixedParams().par().nthreads();
         ExecutorService es = Executors.newFixedThreadPool(nThreads);
@@ -85,4 +144,5 @@ public final class AncEstimator {
         MultiThreadUtils.shutdownExecService(es);
         return estAnc;
     }
+
 }

--- a/src/admix/GtAncParser.java
+++ b/src/admix/GtAncParser.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2023 Genomics plc
+ *
+ * This file is part of the flare program.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package admix;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import blbutil.Const;
+import blbutil.StringUtil;
+import blbutil.Utilities;
+
+/**
+ * <p>Class {@code GtAncParser} parses the file passed in using the `gt-ancestries`
+ * option.</p>
+ *
+ * @author Thomas Hickman {@code <thomas.hickman@genomicsplc.com>}
+ */
+public class GtAncParser {
+    private double[][] sampleToMu;
+    private Set<String> samplesParsed;
+
+    private final Map<String, Integer> sampleIdsToSampleIndex;
+    private final int nAncestries;
+    private final File gtAncestriesFile;
+
+    /**
+     * Constructs a new {@code GtAncParser} instance for the specified file.
+     * analysis
+     * @param gtAncestriesFile the file to parse
+     * @param sampleIdsInGtFile the sample IDs in the target genotype file 
+     * (used for cross-checking the gt-ancestries file)
+     * @param ancIds the ancestry IDs used in ancestry estimation (used 
+     * for cross-checking the gt-ancestries file)
+     */
+    public GtAncParser(File gtAncestriesFile, String[] sampleIdsInGtFile, String[] ancIds) {
+        this.sampleToMu = new double[sampleIdsInGtFile.length][ancIds.length];
+
+        this.sampleIdsToSampleIndex = new HashMap<String, Integer>(sampleIdsInGtFile.length);
+        for (int i = 0; i < sampleIdsInGtFile.length; i++) {
+            sampleIdsToSampleIndex.put(sampleIdsInGtFile[i], i);
+        }
+
+        this.gtAncestriesFile = gtAncestriesFile;
+        this.nAncestries = ancIds.length;
+
+        this.samplesParsed = new HashSet<String>();
+        String[] lines = AdmixUtils.readLines(gtAncestriesFile);
+
+        checkNonEmpty(lines);
+        checkHeader(lines[0], ancIds);
+
+        for (String line : Arrays.copyOfRange(lines, 1, lines.length)) {
+            parseLine(line);
+        }
+
+        checkHaveParsedRequiredSamples(sampleIdsInGtFile);
+    }
+    
+    private void parseLine(String line) {
+        String[] fields = StringUtil.getFields(line);
+        // Note: this is never going to fail, as `readLines` (called in the caller) does not pass us blank lines.
+        String sampleId = fields[0];
+        checkNonDuplicateSample(sampleId);
+
+        double[] mu = Arrays.stream(fields).skip(1).mapToDouble(Double::parseDouble).toArray();
+
+        checkMuIsAProportion(sampleId, mu);
+        checkMuLength(sampleId, mu);
+
+        Integer sampleIndex = sampleIdsToSampleIndex.get(sampleId);
+        if (sampleIndex == null) {
+            // Ignore samples in the gt-ancestries file that aren't in the target file.
+            return;
+        }
+
+        sampleToMu[sampleIdsToSampleIndex.get(sampleId)] = mu;
+        samplesParsed.add(sampleId);
+    }
+
+    private void checkMuLength(String sampleId, double[] mu) {
+        if (mu.length != nAncestries) {
+            String err = "The gt-ancestries file contains a line with an incorrect number of ancestry proportions";
+            String info = Const.nl + "Error                                   :  " + err
+                        + Const.nl + "Filename                                :  " + gtAncestriesFile
+                        + Const.nl + "Sample ID                               :  " + sampleId
+                        + Const.nl + "Expected number of ancestry proportions :  " + nAncestries
+                        + Const.nl + "Found number of ancestry proportions    :  " + mu.length;
+
+            Utilities.exit(new Throwable(err), info);
+        }
+    }
+
+    private void checkMuIsAProportion(String sampleId, double[] mu) {
+        for (double prob : mu) {
+            if (prob < 0f || prob > 1f) {
+                String err = "The gt-ancestries file contains a probability that is less than 0.0 or greater than 1.0";
+                String info = Const.nl + "Error       :  " + err
+                            + Const.nl + "Filename    :  " + gtAncestriesFile
+                            + Const.nl + "Sample ID   :  " + sampleId
+                            + Const.nl + "Probability :  " + prob;
+
+                Utilities.exit(new Throwable(err), info);
+            }
+        }
+
+        double tolerance = 0.01f;
+        double muSum = AdmixUtils.sum(mu);
+        if (Math.abs(1f - muSum) > tolerance) {
+            String err = "The gt-ancestries file contains a sample which has probabilities that do not sum to 1";
+            String info = Const.nl + "Error           :  " + err
+                        + Const.nl + "Filename        :  " + gtAncestriesFile
+                        + Const.nl + "Sample ID       :  " + sampleId
+                        + Const.nl + "Probability sum :  " + muSum;
+
+            Utilities.exit(new Throwable(err), info);
+        }
+    }
+
+    private void checkNonDuplicateSample(String sampleId) {
+        if (samplesParsed.contains(sampleId)) {
+            String err = "The gt-ancestries file contains a duplicate sample ID";
+            String info = Const.nl + "Error     :  " + err
+                        + Const.nl + "Filename  :  " + gtAncestriesFile
+                        + Const.nl + "Sample ID :  " + sampleId;
+
+            Utilities.exit(new Throwable(err), info);
+        }
+    }
+
+    private void checkHaveParsedRequiredSamples(String[] sampleIdsInGenotypeFile) {
+        if (!samplesParsed.containsAll(Arrays.asList(sampleIdsInGenotypeFile))) {
+            String err = "The gt-ancestries file does not contain all the samples in the genotype file";
+            String info = Const.nl + "Error          :  " + err
+                        + Const.nl + "Filename       :  " + gtAncestriesFile;
+
+            Utilities.exit(new Throwable(err), info);
+        }
+    }
+
+    private void checkNonEmpty(String[] lines) {
+        if (lines.length == 0) {
+            String err = "The gt-ancestries file does not contain any content";
+            String info = Const.nl + "Error          :  " + err
+                        + Const.nl + "Filename       :  " + gtAncestriesFile;
+
+            Utilities.exit(new Throwable(err), info);
+        }
+    }
+
+    private void checkHeader(String headerLine, String[] ancIds) {
+        String[] headerFields = StringUtil.getFields(headerLine);
+        String[] headerAncestries = Arrays.copyOfRange(headerFields, 1, headerFields.length);
+
+        if (!Arrays.equals(headerAncestries, ancIds)) {
+            String err = "The gt-ancestries file does not contain a header with the same ancestries as are defined in the model file";
+            String info = Const.nl + "Error             :  " + err
+                        + Const.nl + "Filename          :  " + gtAncestriesFile
+                        + Const.nl + "File Ancestries   :  " + Arrays.toString(headerAncestries)
+                        + Const.nl + "Model Ancestries  :  " + Arrays.toString(ancIds);
+
+            Utilities.exit(new Throwable(err), info);
+        }
+    }
+
+    /**
+     * Gets the ancestry proportions for a given sample.
+     * @param sampleI the index of the sample to query
+     * @returns an array of ancestry proportions (which can be used in the 
+     * `mu` parameter).
+     */
+    public double[] getMu(int sampleI) {
+        return sampleToMu[sampleI];
+    }
+}

--- a/src/admix/ModelFileWithGtAncParams.java
+++ b/src/admix/ModelFileWithGtAncParams.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 Genomics plc
+ *
+ * This file is part of the flare program.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package admix;
+
+
+/**
+ * <p>Class {@code ModelFileWithGtAncParams} represents the analysis
+ * parameters for a local ancestry inference analysis when the `gt-ancestries`
+ * parameter is used.</p>
+ *
+ * @author Thomas Hickman {@code <thomas.hickman@genomicsplc.com>}
+ */
+public class ModelFileWithGtAncParams extends ModelFileParams {
+    private final GtAncParser gtAncestries;
+    private final Integer sampleIndex;
+
+    public ModelFileWithGtAncParams(FixedParams fixedParams, GtAncParser gtAncestries, int sampleI) {
+        super(fixedParams);
+        this.gtAncestries = gtAncestries;
+        this.sampleIndex = sampleI;
+    }
+
+    @Override
+    public double[] mu() {
+        return this.gtAncestries.getMu(sampleIndex).clone();
+    }
+}

--- a/src/admix/ParamsInterface.java
+++ b/src/admix/ParamsInterface.java
@@ -2,7 +2,7 @@ package admix;
 
 /**
  * <p>Interface {@code ParamsInterface} represents the analysis parameters
- * for a local ancestry inference analysis.</p>
+ * for a local ancestry inference analysis for a given sample.</p>
  *
  * <p>Implementations of interface {@code ParamsInterface} are required to be
  * immutable.</p>
@@ -26,7 +26,7 @@ public interface ParamsInterface {
     /**
      * Returns  an array of length {@code this.fixedParams().nAnc()}
      * whose {@code i}-th entry is the proportion of ancestry {@code i}
-     * in the target samples.
+     * in the target sample's population.
      * @return an array of length {@code this.fixedParams().nAnc()}
      * whose {@code i}-th entry is the proportion of ancestry {@code i}
      * in the target samples


### PR DESCRIPTION
This MR adds the option to use sample specific ancestry priors in flare. Information on the usage can be found in the changes to the `README.md` file.

While considering the performance implementations and benchmarking the new implementation, we discovered the following facts:
1. When using sample specific ancestry priors, memory can be kept down at minimal cost to runtime if `System.gc()` is executed everytime a new instance of `AdmixData` and `AdmixHmm` is destroyed and created as our implementation of the sample specific priors involves a lot of destruction and creation of these structures.
2. With an unmodified `AdmixHmmProbs` class, when running flare using sample specific ancestry priors, a lot of time is spent constructing the `pRecTqMu`, `rhoFactor`, `pHapChange` and `pNoChange` structures, structures that precompute values to service public methods of the same name. We therefore had a look at changing these public methods to instead dynamically compute these values. However, after we had done this, we determined that it was actually quicker in the non-sample specific ancestry priors case to not precompute these values. This may be due to the fact that floating point calculations are quicker than lookups in non-cached main memory, or due to different overheads in the JVM. Here's some benchmarking to show this is the case:
```bash
$ # Using precomputed `pRecTqMu`, `rhoFactor`, `pHapChange` and `pNoChange` values
$ /usr/bin/time -v java -Xmx50000m -jar flare.jar ref=ref.vcf.gz gt=gt.vcf.gz ref-panel=ref_panel.tsv map=plink.chr1.GRCh37.map model=input.model nthreads=10 em=false probs=true array=true seed=12345 out=unmodified-flare
Copyright (C) 2022 Brian L. Browning
Enter "java -jar flare.jar" to print a list of command line arguments

Program             :  flare.jar  [ version 0.4.2, 21Nov23.67d ]
Start Time          :  09:18 AM UTC on 30 Nov 2023
Max Memory          :  50016 MB

Parameters
  ref               :  ref.vcf.gz
  ref-panel         :  ref_panel.tsv
  gt                :  gt.vcf.gz
  map               :  plink.chr1.GRCh37.map
  out               :  unmodified-flare
  array             :  true
  min-maf           :  0.005
  probs             :  true
  model             :  input.model
  em                :  false
  nthreads          :  10
  seed              :  12345


Note: the minor allele count filter is not applied when 'array=true'

Statistics
  reference samples :  6307
  target samples    :  1244
  markers           :  49169

Wallclock Time      :  18 minutes 27 seconds
End Time            :  09:36 AM UTC on 30 Nov 2023
        Command being timed: "java -Xmx50000m -jar flare.jar ref=ref.vcf.gz gt=gt.vcf.gz ref-panel=ref_panel.tsv map=plink.chr1.GRCh37.map model=input.model nthreads=10 em=false probs=true array=true seed=12345 out=unmodified-flare"
        User time (seconds): 10810.02
        System time (seconds): 48.53
        Percent of CPU this job got: 979%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 18:28.20
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 35213000
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 8832519
        Voluntary context switches: 486649
        Involuntary context switches: 85670
        Swaps: 0
        File system inputs: 0
        File system outputs: 2777216
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0

$ # Not using precomputed `pRecTqMu`, `rhoFactor`, `pHapChange` and `pNoChange` values
$ /usr/bin/time -v java -Xmx50000m -jar ../flare/flare.jar ref=ref.vcf.gz gt=sample_specific
_params/gt.vcf.gz ref-panel=ref_panel.tsv map=plink.chr1.GRCh37.map model=input.model nthreads=10 em=false probs=true array=true seed=12345 out=genomics-modified-flare
Copyright (C) 2022 Brian L. Browning
Enter "java -jar flare.jar" to print a list of command line arguments

Program             :  flare.jar  [ version 0.4.2, 21Nov23.67d ]
Start Time          :  10:12 AM UTC on 30 Nov 2023
Max Memory          :  50016 MB

Parameters
  ref               :  ref.vcf.gz
  ref-panel         :  ref_panel.tsv
  gt                :  gt.vcf.gz
  map               :  plink.chr1.GRCh37.map
  out               :  genomics-modified-flare
  array             :  true
  min-maf           :  0.005
  probs             :  true
  model             :  input.model
  em                :  false
  nthreads          :  10
  seed              :  12345


Note: the minor allele count filter is not applied when 'array=true'

Statistics
  reference samples :  6307
  target samples    :  1244
  markers           :  49169

Wallclock Time      :  13 minutes 15 seconds
End Time            :  10:25 AM UTC on 30 Nov 2023
Peak Used Memory    :  38,416,910,816
        Command being timed: "java -Xmx50000m -jar ../flare/flare.jar ref=ref.vcf.gz gt=gt.vcf.gz ref-panel=ref_panel.tsv map=plink.chr1.GRCh37.map model=input.model nthreads=10 em=false probs=true array=true seed=12345 out=genomics-modified-flare"
        User time (seconds): 7718.81
        System time (seconds): 52.15
        Percent of CPU this job got: 975%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 13:16.37
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 39058000
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 2
        Minor (reclaiming a frame) page faults: 9790705
        Voluntary context switches: 447809
        Involuntary context switches: 54397
        Swaps: 0
        File system inputs: 64
        File system outputs: 2776608
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0

$ diff -s genomics-modified-flare.anc.vcf.gz unmodified-flare.anc.vcf.gz
Files genomics-modified-flare.anc.vcf.gz and unmodified-flare.anc.vcf.gz are identical
```
### Benchmarking the configurable sample specific ancestry priors mode
```bash
$ /usr/bin/time -v java -Xmx50000m -jar flare.jar ref=ref.vcf.gz gt=gt.vcf.gz ref-panel=ref_panel.tsv map=plink.chr1.GRCh37.map model=input.model nthreads=10 em=false probs=true array=true seed=12345 out=benchmark gt-ancestries=gt-ancestries.tsv
Copyright (C) 2022 Brian L. Browning
Enter "java -jar flare.jar" to print a list of command line arguments

Program             :  flare.jar  [ version 0.4.2, 21Nov23.67d ]
Start Time          :  11:12 AM UTC on 30 Nov 2023
Max Memory          :  50016 MB

Parameters
  ref               :  ref.vcf.gz
  ref-panel         :  ref_panel.tsv
  gt                :  gt.vcf.gz
  map               :  plink.chr1.GRCh37.map
  out               :  benchmark
  array             :  true
  min-maf           :  0.005
  probs             :  true
  model             :  input.model
  gt-ancestries     :  gt-ancestries.tsv
  em                :  false
  nthreads          :  10
  seed              :  12345


Note: the minor allele count filter is not applied when 'array=true'

Statistics
  reference samples :  6307
  target samples    :  1244
  markers           :  49169

Wallclock Time      :  15 minutes 13 seconds
End Time            :  11:27 AM UTC on 30 Nov 2023
Peak Used Memory    :  29,401,589,928
        Command being timed: "java -Xmx50000m -jar flare.jar ref=ref.vcf.gz gt=gt.vcf.gz ref-panel=ref_panel.tsv map=plink.chr1.GRCh37.map model=input.model nthreads=10 em=false probs=true array=true seed=12345 out=benchmark gt-ancestries=gt-ancestries.tsv"
        User time (seconds): 8817.88
        System time (seconds): 71.62
        Percent of CPU this job got: 971%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 15:14.75
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 33825604
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 8942712
        Voluntary context switches: 3318458
        Involuntary context switches: 404629
        Swaps: 0
        File system inputs: 752
        File system outputs: 581728
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```
The `gt-ancestries` does not have a drastically different performance profile to the performance profile without using this flag.

### Validating the configurable sample specific ancestry priors mode
We validate this mode by comparing two samples run individually though the unmodified version flare with model files which have differing `mu` values, then comparing these results with one run though flare using the `gt-ancestries` argument using our modified version of flare:
```bash
$ java -jar flare.jar ref=ref.bref3 ref-panel=ref_panel.tsv gt=gt.vcf.gz map=plink.chr1.GRCh37.map model=HG00173.model nthreads=10 em=false probs=true array=true seed=12345 out=HG00173 gt-samples=<(echo HG00173)
Copyright (C) 2022 Brian L. Browning
Enter "java -jar flare.jar" to print a list of command line arguments

Program             :  flare.jar  [ version 0.4.2, 21Nov23.67d ]
Start Time          :  11:34 AM UTC on 30 Nov 2023
Max Memory          :  16080 MB

Parameters
  ref               :  ref.bref3
  ref-panel         :  ref_panel.tsv
  gt                :  gt.vcf.gz
  map               :  plink.chr1.GRCh37.map
  out               :  HG00173
  array             :  true
  min-maf           :  0.005
  probs             :  true
  model             :  HG00173.model
  em                :  false
  nthreads          :  10
  seed              :  12345
  gt-samples        :  /dev/fd/63


Note: the minor allele count filter is not applied when 'array=true'

Statistics
  reference samples :  6307
  target samples    :  1
  markers           :  49169

Wallclock Time      :  42 seconds
End Time            :  11:35 AM UTC on 30 Nov 2023

$ java -jar flare.jar ref=ref.bref3 ref-panel=ref_panel.tsv gt=gt.vcf.gz map=plink.chr1.GRCh37.map model=HG00174.model nthreads=10 em=false probs=true array=true seed=12345 out=HG00174 gt-samples=<(echo HG00174)
Copyright (C) 2022 Brian L. Browning
Enter "java -jar flare.jar" to print a list of command line arguments

Program             :  flare.jar  [ version 0.4.2, 21Nov23.67d ]
Start Time          :  11:34 AM UTC on 30 Nov 2023
Max Memory          :  16080 MB

Parameters
  ref               :  ref.bref3
  ref-panel         :  ref_panel.tsv
  gt                :  gt.vcf.gz
  map               :  plink.chr1.GRCh37.map
  out               :  HG00174
  array             :  true
  min-maf           :  0.005
  probs             :  true
  model             :  HG00174.model
  em                :  false
  nthreads          :  10
  seed              :  12345
  gt-samples        :  /dev/fd/63


Note: the minor allele count filter is not applied when 'array=true'

Statistics
  reference samples :  6307
  target samples    :  1
  markers           :  49169

Wallclock Time      :  42 seconds
End Time            :  11:35 AM UTC on 30 Nov 2023

$ java -jar flare.jar ref=ref.bref3 ref-panel=ref_panel.tsv gt=gt.vcf.gz map=plink.chr1.GRCh37.map model=HG00173.model nthreads=10 em=false probs=true array=true seed=12345 out=combined-run gt-samples=<(echo HG00173; echo HG00174) gt-ancestries=
ancestry_proportions.tsv
Copyright (C) 2022 Brian L. Browning
Enter "java -jar flare.jar" to print a list of command line arguments

Program             :  flare.jar  [ version 0.4.2, 21Nov23.67d ]
Start Time          :  11:39 AM UTC on 30 Nov 2023
Max Memory          :  16080 MB

Parameters
  ref               :  ref.bref3
  ref-panel         :  ref_panel.tsv
  gt                :  gt.vcf.gz
  map               :  plink.chr1.GRCh37.map
  out               :  combined-run
  array             :  true
  min-maf           :  0.005
  probs             :  true
  model             :  HG00173.model
  gt-ancestries     :  ancestry_proportions.tsv
  em                :  false
  nthreads          :  10
  seed              :  12345
  gt-samples        :  /dev/fd/63


Note: the minor allele count filter is not applied when 'array=true'

Statistics
  reference samples :  6307
  target samples    :  2
  markers           :  49169

Wallclock Time      :  32 seconds
End Time            :  11:40 AM UTC on 30 Nov 2023
Peak Used Memory    :  3,766,437,264
$ # Index to make bcftools happy
$ bcftools index HG00173.anc.vcf.gz
$ bcftools index combined-run.anc.vcf.gz
$ # Use `bcftools view -s` on both so `AC` and `AN` fields appear in both files
$ diff -s <(bcftools view -s HG00173 -H HG00173.anc.vcf.gz) <(bcftools view -s HG00173 -H combined-run.anc.vcf.gz)
Files /dev/fd/63 and /dev/fd/62 are identical
$ bcftools index HG00174.anc.vcf.gz
$ diff -s <(bcftools view -s HG00174 -H HG00174.anc.vcf.gz) <(bcftools view -s HG00174 -H combined-run.anc.vcf.gz)
Files /dev/fd/63 and /dev/fd/62 are identical
```

In this implementation, we also write out the model file provided to the output folder unmodified, which could confuse someone looking at the output model file. If you think this is a problem, we could have a look at getting flare to accept `NaN`s in the mu section of the model, and output a model file with `NaN`s in this section in another PR.