### PR TITLE
Correct the sample specific ancestry priors implementation

### DIFF
--- a/src/admix/AdmixHmmProbs.java
+++ b/src/admix/AdmixHmmProbs.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2021-2023 Brian L. Browning
- *
+ * Copyright 2024 Genomics plc
  * This file is part of the flare program.
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -162,6 +162,17 @@ public class AdmixHmmProbs {
      */
     public double sampleMu(int sample, int ancestry) {
         return sampleMu[sample][ancestry];
+    }
+
+    /**
+     * Returns all the ancestry proportions for the specified sample
+     * @param sample a sample index
+     * @return an array containing the ancestry proportions for the specified sample
+     * @throws IndexOutOfBoundsException if
+     * {@code (sample < 0 || sample >= this.nTargSamples())}
+     */
+    public double[] sampleMu(int sample) {
+        return sampleMu[sample].clone();
     }
 
     /**

--- a/src/admix/GlobalAncestries.java
+++ b/src/admix/GlobalAncestries.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2021-2023 Brian L. Browning
+ * Copyright 2024 Genomics plc
  *
  * This file is part of the flare program.
  *
@@ -91,6 +92,13 @@ public class GlobalAncestries {
         IntList tempSampleIndices = new IntList();
         ArrayList<double[]> tempAncestryProbs = new ArrayList<>();
         this.nAnc = expectedAncIds.length;
+        String[] foundAncIds = readAncIds(gtAncFile);
+        if (!Arrays.equals(foundAncIds, expectedAncIds)) {
+            String err = "Error: expected ancestries in gt-ancestries file to be: "
+                    + Arrays.toString(expectedAncIds) + ", found: " + Arrays.toString(expectedAncIds);
+            printErrAndExit(err, gtAncFile, null);
+        }
+
         try (FileIt<String> it = InputIt.fromGzipFile(gtAncFile)) {
             readLines(it, lines, 1); // read header line
             if (lines.size()==1) {

--- a/src/admix/ParamUtils.java
+++ b/src/admix/ParamUtils.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright 2021-2023 Brian L. Browning
+ * Copyright 2024 Genomics plc
+ *
+ * This file is part of the flare program.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package admix;
 
 import blbutil.Const;
@@ -64,9 +83,10 @@ public class ParamUtils {
     /**
      * Returns a two-dimensional array obtained that is obtained by taking
      * the matrix product of {@code ParamUtils.q(params)}
-     * and {@code params.mu()}.
+     * and {@code mu}.
      * The {@code (i, j)}-th element of the returned array is
      * {@code params.mu()[i]*params.p()[i][j]/params.fixedParams().nPanelHaps()[j]}
+     * @param params the value of `mu`. This could either be the study mu or the sample specific mu.
      * @param params the parameters for a local ancestry analysis
      *
      * @return a two-dimensional array obtained that is obtained by taking
@@ -74,10 +94,9 @@ public class ParamUtils {
      * and {@code params.mu()}
      * @throws NullPointerException if {@code params == null}
      */
-   public  static double[][] qMu(ParamsInterface params) {
+   public static double[][] qMu(double[] mu, ParamsInterface params) {
         IntArray nPanelHaps = params.fixedParams().nPanelHaps();
         double[][] modP = params.p();
-        double[] mu = params.studyMu();
         double[] invNPanelHaps = new double[nPanelHaps.size()];
         for (int j=0, n=nPanelHaps.size(); j<n; ++j) {
             invNPanelHaps[j] = 1.0/nPanelHaps.get(j);


### PR DESCRIPTION
This correct 0.5.0 to ensure that it's output is the same as in https://github.com/browning-lab/flare/pull/9.

This also wires up `readAncIds` so header values in the `gtAncestries` file are checked.

Output from this branch:
```
$ java -Xmx30000m -jar flare.jar ref=ref.vcf.gz gt=gt.vcf.gz ref-panel=ref_panel.tsv map=plink.chr1.GRCh37.map model=input.model gt-samples=gt_samples.txt gt-ancestries=ancestry_proportions.tsv nthreads=10 em=false probs=true array=true seed=12345 out=v0.5-with-fixes
Copyright (C) 2021-2023 Brian L. Browning
Enter "java -jar flare.jar" to print a list of command line arguments

Program             :  flare.jar  [ version 0.5.0, 05Jan24.e0b ]
Start Time          :  03:54 PM GMT on 09 Jan 2024
Max Memory          :  30000 MB

Parameters
  ref               :  ref.vcf.gz
  ref-panel         :  ref_panel.tsv
  gt                :  gt.vcf.gz
  map               :  plink.chr1.GRCh37.map
  out               :  v0.5-with-fixes
  array             :  true
  min-maf           :  0.005
  probs             :  true
  model             :  input.model
  em                :  false
  gt-samples        :  gt_samples.txt
  gt-ancestries     :  ancestry_proportions.tsv
  nthreads          :  10
  seed              :  12345


Note: the minor allele count filter is not applied when 'array=true'

Statistics
  reference samples :  6307
  target samples    :  15
  markers           :  49169

Wallclock Time      :  47 seconds
End Time            :  03:55 PM GMT on 09 Jan 2024
```
Output from https://github.com/browning-lab/flare/pull/9:
```
$ java -Xmx30000m -jar build/flare/flare.jar ref=ref.vcf.gz gt=gt.vcf.gz ref-panel=ref_panel.tsv map=plink.chr1.GRCh37.map model=input.model gt-samples=gt_samples.txt gt-ancestries=ancestry_proportions.tsv nthreads=10 em=false probs=true array=true seed=12345 out=genomics-version
Copyright (C) 2022 Brian L. Browning
Enter "java -jar flare.jar" to print a list of command line arguments

Program             :  flare.jar  [ version 0.4.2, 21Nov23.67d ]
Start Time          :  03:57 PM GMT on 09 Jan 2024
Max Memory          :  30000 MB

Parameters
  ref               :  ref.vcf.gz
  ref-panel         :  ref_panel.tsv
  gt                :  gt.vcf.gz
  map               :  plink.chr1.GRCh37.map
  out               :  genomics-version
  array             :  true
  min-maf           :  0.005
  probs             :  true
  model             :  input.model
  gt-ancestries     :  ancestry_proportions.tsv
  em                :  false
  nthreads          :  10
  seed              :  12345
  gt-samples        :  gt_samples.txt


Note: the minor allele count filter is not applied when 'array=true'

Statistics
  reference samples :  6307
  target samples    :  15
  markers           :  49169

Wallclock Time      :  46 seconds
End Time            :  03:57 PM GMT on 09 Jan 2024
Peak Used Memory    :  5,036,540,104
```

Comparing them both:
```
$ diff -s <(bcftools view -H v0.5-with-fixes.anc.vcf.gz ) <(bcftools view -H genomics-version.anc.vcf.gz )
[W::vcf_parse] Contig '1' is not defined in the header. (Quick workaround: index the file with tabix.)
[W::vcf_parse] Contig '1' is not defined in the header. (Quick workaround: index the file with tabix.)
Files /dev/fd/63 and /dev/fd/62 are identical
```